### PR TITLE
Add Codex agent support to RedCode-Gen

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ conda activate redcode
 ./scripts/OCI_eval.sh
 ./scripts/RA_eval.sh
 ./scripts/CA_eval.sh
+# example for Codex generation benchmark
+python evaluation/RedCode_Gen/main.py --model codex --codex_cmd /path/to/codex
 ```
 
 Currently, the scripts are run separately. We are working on merging them into a unified script to provide a better user experience.

--- a/evaluation/RedCode_Gen/README.md
+++ b/evaluation/RedCode_Gen/README.md
@@ -13,4 +13,7 @@ python main.py --model claude-3-opus-20240229 --evaluation_type agent --rounds 3
 
 # To include VirusTotal evaluation
 python main.py --model gpt-3.5-turbo --evaluation_type normal --use_virustotal
+
+# Evaluate the Codex agent
+python main.py --model codex --codex_cmd /path/to/codex
 ```

--- a/evaluation/RedCode_Gen/clients.py
+++ b/evaluation/RedCode_Gen/clients.py
@@ -2,6 +2,7 @@ from abc import ABC, abstractmethod
 from openai import OpenAI
 from together import Together
 import anthropic
+import subprocess
 
 class LLMClient(ABC):
     @abstractmethod
@@ -65,6 +66,22 @@ class AnthropicClient(LLMClient):
         )
         return message.content[0].text
 
+class CodexClient(LLMClient):
+    """Simple wrapper around the Codex CLI agent."""
+
+    def __init__(self, cmd: str):
+        self.cmd = cmd
+
+    def generate(self, system, user_request):
+        prompt = f"{system}\n{user_request}"
+        result = subprocess.run(
+            [self.cmd],
+            input=prompt,
+            text=True,
+            capture_output=True,
+        )
+        return result.stdout
+
 def get_client(config):
     if config["model"].startswith("gpt"):
         return OpenAIClient(config["openai_api_key"], config["model"])
@@ -72,5 +89,7 @@ def get_client(config):
         return TogetherClient(config["together_api_key"], config["model"])
     elif config["model"].startswith("claude"):
         return AnthropicClient(config["anthropic_api_key"], config["model"])
+    elif config["model"].lower() == "codex":
+        return CodexClient(config.get("codex_cmd", "codex"))
     else:
         raise ValueError(f"Unsupported model: {config['model']}")

--- a/evaluation/RedCode_Gen/config.py
+++ b/evaluation/RedCode_Gen/config.py
@@ -13,6 +13,7 @@ def get_config():
     parser.add_argument("--evaluation_type", choices=["normal", "agent"], default="normal", help="Type of evaluation to perform")
     parser.add_argument("--rounds", type=int, default=5, help="Number of rounds for agent evaluation")
     parser.add_argument("--use_virustotal", action="store_true", help="Use VirusTotal for additional evaluation")
+    parser.add_argument("--codex_cmd", default=os.getenv("CODEX_CMD", "codex"), help="Codex CLI command")
     args = parser.parse_args()
 
     config = {
@@ -23,6 +24,7 @@ def get_config():
         "evaluation_type": args.evaluation_type,
         "rounds": args.rounds,
         "use_virustotal": args.use_virustotal,
+        "codex_cmd": args.codex_cmd,
         "openai_api_key": os.getenv("OPENAI_API_KEY"),
         "together_api_key": os.getenv("TOGETHER_API_KEY"),
         "anthropic_api_key": os.getenv("ANTHROPIC_API_KEY"),


### PR DESCRIPTION
## Summary
- support `codex` model in RedCode-Gen evaluation
- document how to run evaluation with the Codex agent

## Testing
- `python -m compileall -q .`